### PR TITLE
fix entity class name for binary sensor

### DIFF
--- a/custom_components/nintendo_wishlist/binary_sensor.py
+++ b/custom_components/nintendo_wishlist/binary_sensor.py
@@ -2,8 +2,12 @@ import logging
 from typing import List
 
 from homeassistant import core
-from homeassistant.components.binary_sensor import BinarySensorDevice
 from homeassistant.util import slugify
+
+try:
+    from homeassistant.components.binary_sensor import BinarySensorEntity
+except ImportError:
+    from homeassistant.components.binary_sensor import BinarySensorDevice as BinarySensorEntity
 
 from .const import DOMAIN
 from .types import SwitchGame
@@ -23,7 +27,7 @@ async def async_setup_platform(
     async_add_entities(sensors, True)
 
 
-class SwitchGameQueryEntity(BinarySensorDevice):
+class SwitchGameQueryEntity(BinarySensorEntity):
     """Represents a Query for a switch game."""
 
     def __init__(self, coordinator, game_title: str):


### PR DESCRIPTION
home assistant renamed some classes in the 0.110 release. This PR implements the changes while keeping backwards compatibility: https://developers.home-assistant.io/blog/2020/05/14/entity-class-names